### PR TITLE
Incorrectly handled BGWH_STOPPED from WaitForBackgroundWorkerStartup

### DIFF
--- a/pg_background.c
+++ b/pg_background.c
@@ -227,13 +227,9 @@ pg_background_launch(PG_FUNCTION_ARGS)
 			/* Success. */
 			break;
 		case BGWH_STOPPED:
-			pfree(worker_handle);
-			ereport(ERROR,
-					(errcode(ERRCODE_INSUFFICIENT_RESOURCES),
-					 errmsg("could not start background process"),
-					 errhint("More details may be available in the server log.")));
+			/* Success and already done. */
 			break;
-        case BGWH_POSTMASTER_DIED:
+		case BGWH_POSTMASTER_DIED:
 			pfree(worker_handle);
 			ereport(ERROR,
 					(errcode(ERRCODE_INSUFFICIENT_RESOURCES),


### PR DESCRIPTION
BGWH_STOPPED does not mean that the background process could not have been started, but it means it already exited - see the relevant documentation part: https://www.postgresql.org/docs/current/bgworker.html, there is no indication that error should be raised for such a return value:
> ... and BGWH_STOPPED indicates that it has been started but is no longer running

In our environment, pg_background_launch unpredictably and very rarely failed when BGWH_STOPPED branch was matched ("could not start background process" was reported in the log and it is the only place in the code with this message), but the process results were present and OK.